### PR TITLE
'-f' isn't a valid elasticsearch option

### DIFF
--- a/run
+++ b/run
@@ -140,4 +140,4 @@ if [ -n "$MAX_MAP_COUNT" ]; then
 fi
 
 # Start Daemon
-exec sudo -u $ES_USER $DAEMON -f $DAEMON_OPTS
+exec sudo -u $ES_USER $DAEMON $DAEMON_OPTS


### PR DESCRIPTION
elasticsearch should run in the foreground unless '-d' is specified.
